### PR TITLE
Support floating-point tokens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/**
 .vscode/**
+.*.swp
+.*.swo

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -15,6 +15,7 @@ pub enum TokenKind {
     EqualSign,
     Identifier,
     Integer,
+    FloatingPoint,
     LeftBrace,
     LeftParen,
     LeftSqBracket,
@@ -160,7 +161,18 @@ impl<'a> Lexer<'a> {
                 token = self.char_token(TokenKind::Divide);
             }
             '.' => {
-                token = self.char_token(TokenKind::Period);
+                let p = self.peek_char();
+                if p.is_ascii_digit() {
+                    if let Some(t) = self.read_decimal_part(self.position) {
+                        token = t;
+                    }
+                    else {
+                        token = self.char_token(TokenKind::Period);
+                    }
+                }
+                else {
+                    token = self.char_token(TokenKind::Period);
+                }
             }
             '=' => match self.peek_char() {
                 '=' => {
@@ -247,9 +259,9 @@ impl<'a> Lexer<'a> {
                         token = self.read_junk();
                     }
                 }
-                // read integer
+                // read number
                 else if c.is_ascii_digit() {
-                    if let Some(t) = self.read_integer() {
+                    if let Some(t) = self.read_number() {
                         token = t;
                     } else {
                         token = self.read_junk();
@@ -351,12 +363,23 @@ impl<'a> Lexer<'a> {
         self.text_token(start, TokenKind::String)
     }
 
-    fn read_integer(&mut self) -> Option<Token<'a>> {
+    fn read_number(&mut self) -> Option<Token<'a>> {
         let start = self.position;
+
         while self.peek_char().is_ascii_digit() {
             self.read_char();
         }
 
+        let p = self.peek_char();
+        match p {
+            '.' => self.read_decimal_part(start),
+            'e' => self.read_exponent(start),
+            'E' => self.read_exponent(start),
+            _ => self.read_number_final_integer(start),
+        }
+    }
+
+    fn read_number_final_integer(&mut self, start: usize) -> Option<Token<'a>> {
         let p = self.peek_char();
         if p.is_ascii_alphabetic() {
             self.reset(start);
@@ -365,6 +388,62 @@ impl<'a> Lexer<'a> {
 
         Some(self.text_token(start, TokenKind::Integer))
     }
+
+    fn read_decimal_part(&mut self, start: usize) -> Option<Token<'a>> {
+        self.read_char(); // consume the '.'
+
+        while self.peek_char().is_ascii_digit() {
+            self.read_char();
+        }
+
+        let p = self.peek_char();
+        match p {
+            'e' => self.read_exponent(start),
+            'E' => self.read_exponent(start),
+            _ => self.read_number_final_floating_point(start),
+        }
+    }
+
+    fn read_exponent(&mut self, start: usize) -> Option<Token<'a>> {
+        self.read_char(); // consume the 'e' or 'E'
+
+        let p = self.peek_char();
+        if p == '+' || p == '-' {
+            self.read_char();
+        }
+        else if !p.is_ascii_digit()
+        {
+            return self.read_number_cleanup_junk(start);
+        }
+
+        self.read_number_final_floating_point(start)
+    }
+
+    fn read_number_final_floating_point(&mut self, start: usize) -> Option<Token<'a>> {
+        while self.peek_char().is_ascii_digit() {
+            self.read_char()
+        }
+
+        let p = self.peek_char();
+        if p.is_ascii_alphabetic() {
+            return self.read_number_cleanup_junk(start);
+        }
+        
+        Some(self.text_token(start, TokenKind::FloatingPoint))
+    }
+
+    fn read_number_cleanup_junk(&mut self, start: usize) -> Option<Token<'a>> {
+        // What we have read is not compatible with a number.  We cannot
+        // rely on the general junk reader to tidy up because we may have
+        // decimal points, exponent symbols and sign symbols in the mix.
+
+        while self.peek_char().is_ascii_alphanumeric() {
+            self.read_char();
+        }
+
+        Some(self.text_token(start, TokenKind::Unknown))
+    }
+
 }
 
 #[cfg(test)]
@@ -560,6 +639,97 @@ mod lexer_test {
                     ("!=", TokenKind::NotEquals),
                     ("b", TokenKind::Identifier),
                     (";", TokenKind::SemiColon),
+                ],
+            },
+            TestCase {
+                input: "3",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("3", TokenKind::Integer),
+                ],
+            },
+            TestCase {
+                input: "314",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("314", TokenKind::Integer),
+                ],
+            },
+            TestCase {
+                input: "3.14",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("3.14", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "3.",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("3.", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: ".14",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    (".14", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "3e8",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("3e8", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "0.314e1",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("0.314e1", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "9.1e-31",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("9.1e-31", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "6.02e+23",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("6.02e+23", TokenKind::FloatingPoint),
+                ],
+            },
+            TestCase {
+                input: "2e",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("2e", TokenKind::Unknown),
+                ],
+            },
+            TestCase {
+                input: "2.e",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("2.e", TokenKind::Unknown),
+                ],
+            },
+            TestCase {
+                input: "2.4f",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("2.4f", TokenKind::Unknown),
+                ],
+            },
+            TestCase {
+                input: "2.4e3a",
+                skip_whitespace: false,
+                expected_tokens: vec![
+                    ("2.4e3a", TokenKind::Unknown),
                 ],
             },
         ];


### PR DESCRIPTION
This commit extends the support for reading numeric values by permitting
floating-point tokens of the forms listed below:

```
    1.2
    1.
    .2
    1e3
    1e+3
    1e-3
    1.2e3
    1.2e-3
    1.2e+3
    .2e3
    .2e-3
    .2e+3
```

This is done by replacing `read_integer()` with `read_number`, returning
tokens of kind `Integer`, `FloatingPoint`, or `Unknown`.

The `Unknown` token kind is returned when attempting to tokenize a
floating-point value fails due to unexpected alphanumeric chars. In this
case, the general "junk" tokenizer cannot be used because we may have
accepted one of `.+-eE` in the token already. One failure mode that was
already seen (and for which a test exists) is the token `2.1e`. This
should yield an `Unknown` token to skip past the junk, but with the
general junk parser it would return an Integer token `2`, a Period
token, then a `1e` Unknown token.

Arguably it is a design decision to capture this as a single junk token
rather than two valid tokens and one invalid. It seems more likely that
this approach will lead to better diagnostics later in translation,
compared to accepting a valid integer and period token and not reporting
them in the error message that would be generated for the `1e` junk
token. It also avoids the possible interpretation of `2.1e3.2` as
something like
```
Integer(2)
Period(.)
FloatingPoint(1e3)
FloatingPoint(.2)
```
instead preferring
```
Unknown(2.1e3)
FloatingPoint(.2)
```
which is still incorrect, but generates an `Unknown` from which an error
could be triggered, rather than making valid tokens out of what is
obviously an erroneous sequence of characters.