### PR TITLE
Handle unary operators `+` and `-` for integer and floating-point expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -191,15 +191,13 @@ impl<'a> Parser<'a> {
                 None
             }
             TokenKind::Plus => {
-                if let Some(expr) = self.parse_unary_plus_expression()
-                {
+                if let Some(expr) = self.parse_unary_plus_expression() {
                     return Some(ExpressionStatement::UnaryPlusExpression(expr));
                 }
                 None
             }
             TokenKind::Minus => {
-                if let Some(expr) = self.parse_unary_minus_expression()
-                {
+                if let Some(expr) = self.parse_unary_minus_expression() {
                     return Some(ExpressionStatement::UnaryMinusExpression(expr));
                 }
                 None
@@ -234,8 +232,7 @@ impl<'a> Parser<'a> {
     fn parse_unary_plus_expression(&mut self) -> Option<UnaryPlusExpression> {
         assert!(self.token.kind() == TokenKind::Plus);
         self.read_token(); // consume `+`
-        match self.token.kind()
-        {
+        match self.token.kind() {
             TokenKind::Integer => {
                 if let Some(integer) = self.parse_integer_expression() {
                     return Some(UnaryPlusExpression::IntegerExpression(integer));
@@ -250,9 +247,9 @@ impl<'a> Parser<'a> {
             }
             _ => {
                 self.errors.push(format!(
-                        "Parse error when parsing unary plus expression {:?}",
-                        self.token
-                        ));
+                    "Parse error when parsing unary plus expression {:?}",
+                    self.token
+                ));
                 None
             }
         }
@@ -261,8 +258,7 @@ impl<'a> Parser<'a> {
     fn parse_unary_minus_expression(&mut self) -> Option<UnaryMinusExpression> {
         assert!(self.token.kind() == TokenKind::Minus);
         self.read_token(); // consume `-`
-        match self.token.kind()
-        {
+        match self.token.kind() {
             TokenKind::Integer => {
                 if let Some(integer) = self.parse_integer_expression() {
                     return Some(UnaryMinusExpression::IntegerExpression(integer));
@@ -271,15 +267,17 @@ impl<'a> Parser<'a> {
             }
             TokenKind::FloatingPoint => {
                 if let Some(floating_point) = self.parse_floating_point_expression() {
-                    return Some(UnaryMinusExpression::FloatingPointExpression(floating_point));
+                    return Some(UnaryMinusExpression::FloatingPointExpression(
+                        floating_point,
+                    ));
                 }
                 None
             }
             _ => {
                 self.errors.push(format!(
-                        "Parse error when parsing unary minus expression {:?}",
-                        self.token
-                        ));
+                    "Parse error when parsing unary minus expression {:?}",
+                    self.token
+                ));
                 None
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,11 +18,24 @@ pub struct IdentifierExpression {
 }
 
 #[derive(Debug)]
+pub enum UnaryPlusExpression {
+    IntegerExpression(IntegerExpression),
+    FloatingPointExpression(FloatingPointExpression),
+}
+#[derive(Debug)]
+pub enum UnaryMinusExpression {
+    IntegerExpression(IntegerExpression),
+    FloatingPointExpression(FloatingPointExpression),
+}
+
+#[derive(Debug)]
 pub enum ExpressionStatement {
     StringLiteralExpression(StringLiteralExpression),
     IntegerExpression(IntegerExpression),
     FloatingPointExpression(FloatingPointExpression),
     IdentifierExpression(IdentifierExpression),
+    UnaryPlusExpression(UnaryPlusExpression),
+    UnaryMinusExpression(UnaryMinusExpression),
 }
 #[derive(Debug)]
 pub struct LetStatement {
@@ -177,6 +190,20 @@ impl<'a> Parser<'a> {
                 }
                 None
             }
+            TokenKind::Plus => {
+                if let Some(expr) = self.parse_unary_plus_expression()
+                {
+                    return Some(ExpressionStatement::UnaryPlusExpression(expr));
+                }
+                None
+            }
+            TokenKind::Minus => {
+                if let Some(expr) = self.parse_unary_minus_expression()
+                {
+                    return Some(ExpressionStatement::UnaryMinusExpression(expr));
+                }
+                None
+            }
             _ => {
                 self.errors.push(format!(
                     "Parse error when parsing expression {:?}",
@@ -201,6 +228,60 @@ impl<'a> Parser<'a> {
                 Some(IdentifierExpression { name })
             }
             _ => None,
+        }
+    }
+
+    fn parse_unary_plus_expression(&mut self) -> Option<UnaryPlusExpression> {
+        assert!(self.token.kind() == TokenKind::Plus);
+        self.read_token(); // consume `+`
+        match self.token.kind()
+        {
+            TokenKind::Integer => {
+                if let Some(integer) = self.parse_integer_expression() {
+                    return Some(UnaryPlusExpression::IntegerExpression(integer));
+                }
+                None
+            }
+            TokenKind::FloatingPoint => {
+                if let Some(floating_point) = self.parse_floating_point_expression() {
+                    return Some(UnaryPlusExpression::FloatingPointExpression(floating_point));
+                }
+                None
+            }
+            _ => {
+                self.errors.push(format!(
+                        "Parse error when parsing unary plus expression {:?}",
+                        self.token
+                        ));
+                None
+            }
+        }
+    }
+
+    fn parse_unary_minus_expression(&mut self) -> Option<UnaryMinusExpression> {
+        assert!(self.token.kind() == TokenKind::Minus);
+        self.read_token(); // consume `-`
+        match self.token.kind()
+        {
+            TokenKind::Integer => {
+                if let Some(integer) = self.parse_integer_expression() {
+                    return Some(UnaryMinusExpression::IntegerExpression(integer));
+                }
+                None
+            }
+            TokenKind::FloatingPoint => {
+                if let Some(floating_point) = self.parse_floating_point_expression() {
+                    return Some(UnaryMinusExpression::FloatingPointExpression(floating_point));
+                }
+                None
+            }
+            _ => {
+                self.errors.push(format!(
+                        "Parse error when parsing unary minus expression {:?}",
+                        self.token
+                        ));
+                None
+            }
         }
     }
 
@@ -301,6 +382,18 @@ mod parser_test {
             },
             TestCase {
                 input: r#"let x = "Hello";"#,
+            },
+            TestCase {
+                input: "let x = +1;",
+            },
+            TestCase {
+                input: "let x = -1;",
+            },
+            TestCase {
+                input: "let x = +3.14159;",
+            },
+            TestCase {
+                input: "let x = -3.14159;",
             },
         ];
 


### PR DESCRIPTION

This changeset provides support for expressions of the form `+1`, `-1`,
`+3.14159` and `-3.14159` when parsing integer or floating-point
expressions.

It adds two new variants, `UnaryPlusExpression` and
`UnaryMinusExpression` which can each hold either an `IntegerExpression`
or a `FloatingPointExpression`, and extends `ExpressionStatement` to
support these two new variants.

This completes the support for representing signed numbers, since the
tokenizer parses the preceding `+` or `-` operator separately to the
numeric value.