### PR TITLE
Improve test error reporting in parser tests.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -436,21 +436,25 @@ mod tests {
 
             use std::cmp::Ordering;
             match test_case.expected_errors.len().cmp(&errors.len()) {
-                Ordering::Greater => for expected in &test_case.expected_errors[errors.len()..] {
+                Ordering::Greater => {
+                    for expected in &test_case.expected_errors[errors.len()..] {
                         assert_eq!(
                             *expected, "",
                             "Expected parse error not encountered while parsing {}",
                             test_case.input
                         );
-                    },
-                Ordering::Less => for error in &errors[test_case.expected_errors.len()..] {
+                    }
+                }
+                Ordering::Less => {
+                    for error in &errors[test_case.expected_errors.len()..] {
                         assert_eq!(
                             error, "",
                             "Unexpected parse error encountered while parsing {}",
                             test_case.input
                         );
-                    },
-                Ordering::Equal => {},
+                    }
+                }
+                Ordering::Equal => {}
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -434,22 +434,23 @@ mod tests {
                 );
             }
 
-            if test_case.expected_errors.len() > errors.len() {
-                for expected in &test_case.expected_errors[errors.len()..] {
-                    assert_eq!(
-                        *expected, "",
-                        "Expected parse error not encountered while parsing {}",
-                        test_case.input
-                    );
-                }
-            } else if errors.len() > test_case.expected_errors.len() {
-                for error in &errors[test_case.expected_errors.len()..] {
-                    assert_eq!(
-                        error, "",
-                        "Unexpected parse error encountered while parsing {}",
-                        test_case.input
-                    );
-                }
+            use std::cmp::Ordering;
+            match test_case.expected_errors.len().cmp(&errors.len()) {
+                Ordering::Greater => for expected in &test_case.expected_errors[errors.len()..] {
+                        assert_eq!(
+                            *expected, "",
+                            "Expected parse error not encountered while parsing {}",
+                            test_case.input
+                        );
+                    },
+                Ordering::Less => for error in &errors[test_case.expected_errors.len()..] {
+                        assert_eq!(
+                            error, "",
+                            "Unexpected parse error encountered while parsing {}",
+                            test_case.input
+                        );
+                    },
+                Ordering::Equal => {},
             }
         }
     }


### PR DESCRIPTION
This commit adds the ability for the test suite to report differences
between expected and encountered parse errors, allowing us to test the
error cases as well as correctly parsed examples.