### PR TITLE
no naked `return`s, `Option::map`, unicode test

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -78,9 +78,9 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "stream did not contain valid UTF-8")]
-    fn bad_utf8_input_causes_a_panic() {
-        let bad_utf8: &[u8] = &[0x44, 0xEF];
-        process_stream(bad_utf8, io::sink()).unwrap();
+    fn invalid_utf8_input_causes_a_panic() {
+        let invalid_utf8: &[u8] = &[0x44, 0xEF];
+        process_stream(invalid_utf8, io::sink()).unwrap();
     }
 
     #[test]
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn valid_utf8_input_doesnt_panic() {
-        let good_utf8 = "meow".as_bytes();
-        process_stream(good_utf8, io::sink()).unwrap();
+        let valid_utf8 = "meow".as_bytes();
+        process_stream(valid_utf8, io::sink()).unwrap();
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -84,3 +84,16 @@ impl<'a> fmt::Display for Token<'a> {
         write!(f, "{:?} '{}'", self.kind, self.text())
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::{Kind, Token};
+
+    #[test]
+    fn utf8_token_can_be_constructed_and_unicode_read_from_it() {
+        let sparkle_bytes = vec![240, 159, 146, 150];
+        let sparkle_heart = Token::new(&sparkle_bytes, 0, Kind::Identifier);
+        assert_eq!(sparkle_heart.text(), "💖");
+    }
+}


### PR DESCRIPTION
Refactoring:

* no naked `return`s
* use `Option::map` instead of hand-written `if`-`let` equivalent
* prefer `==` to `!=`

Add one passing unicode test