### PR TITLE
rename mod process to io and clippy refactorings

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn valid_utf8_input_doesnt_panic() {
-        let valid_utf8 = "meow".as_bytes();
+        let valid_utf8: &[u8] = b"meow";
         process_stream(valid_utf8, io::sink()).unwrap();
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// process each filepath in the input Vec, or stdin if empty
-pub fn files(filepaths: Vec<String>) -> Result<()> {
+pub fn process_files(filepaths: Vec<String>) -> Result<()> {
     let stdout = io::stdout();
     let mut outio = stdout.lock();
 
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Failed to open file at /made/up/file/location")]
     fn missing_file_causes_a_panic() {
-        files(vec!["/made/up/file/location".to_string()]).unwrap();
+        process_files(vec!["/made/up/file/location".to_string()]).unwrap();
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -691,9 +691,9 @@ mod tests {
             },
         ];
 
-        for test_case in test_cases.iter() {
+        for test_case in &test_cases {
             let mut lexer = Lexer::new(test_case.input);
-            for expected_token in test_case.expected_tokens.iter() {
+            for expected_token in &test_case.expected_tokens {
                 let mut t = lexer.next_token();
                 while t.kind() == Kind::Whitespace && test_case.skip_whitespace {
                     t = lexer.next_token();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 mod lexer;
 mod parser;
-mod process;
+mod io;
 mod token;
 
 use anyhow::Result;
-use process::files;
+use io::process_files;
 use std::env;
 
 fn main() -> Result<()> {
-    files(env::args().skip(1).collect())
+    process_files(env::args().skip(1).collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
+mod io;
 mod lexer;
 mod parser;
-mod io;
 mod token;
 
 use anyhow::Result;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -343,6 +343,8 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
 
+    use std::cmp::Ordering;
+
     use super::*;
     use crate::lexer::Lexer;
 
@@ -412,7 +414,6 @@ mod tests {
                 );
             }
 
-            use std::cmp::Ordering;
             match test_case.expected_errors.len().cmp(&errors.len()) {
                 Ordering::Greater => {
                     for expected in &test_case.expected_errors[errors.len()..] {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -400,7 +400,7 @@ mod tests {
             },
         ];
 
-        for test_case in test_cases.iter() {
+        for test_case in &test_cases {
             let tokens = Lexer::new(test_case.input).tokens();
             let parser = Parser::new(tokens);
             let ast = parser.ast();

--- a/src/token.rs
+++ b/src/token.rs
@@ -92,8 +92,9 @@ mod tests {
 
     #[test]
     fn utf8_token_can_be_constructed_and_unicode_read_from_it() {
+        // https://unicode-table.com/en/1F496/
         let sparkle_bytes = vec![240, 159, 146, 150];
         let sparkle_heart = Token::new(&sparkle_bytes, 0, Kind::Identifier);
-        assert_eq!(sparkle_heart.text(), "💖");
+        assert_eq!(sparkle_heart.text(), "\u{1f496}");
     }
 }


### PR DESCRIPTION
* rename mod `process` to `io`
* rename `files` to `process_files`
* move the `use` to top of module, which is where it begins its scope
* remove raw non-ascii literals in code
* iterate more iodiomatically