### PR TITLE
add-structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,230 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
 name = "mylang"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "structopt",
 ]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.41"
+structopt = "0.3.21"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -28,7 +28,7 @@ pub struct Opt {
 ///
 /// Will return Err if files couldn't be opened, or found
 /// or if they could not be lexed, parsed or evaluated
-pub fn process_files(opt: &Opt) -> Result<i32> {
+pub fn go(opt: &Opt) -> Result<i32> {
     let stdout = io::stdout();
     let mut outio = stdout.lock();
 
@@ -112,7 +112,7 @@ mod tests {
         let opts = Opt {
             files: vec![PathBuf::from(r"/dev/null/madeupfile")],
         };
-        process_files(&opts).unwrap();
+        go(&opts).unwrap();
     }
 
     #[test]

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -7,9 +7,10 @@ struct Environment {
 }
 enum Value {
     Float(f64),
-    Integer(i64),
+    Integer(i32),
     String(String),
 }
+
 pub struct Evaluator {
     globals: Environment,
     errors: Vec<String>,
@@ -29,7 +30,7 @@ impl Evaluator {
         &self.errors
     }
 
-    pub fn evaluate(&mut self, ast: &AbstractSyntaxTree) -> i64 {
+    pub fn evaluate(&mut self, ast: &AbstractSyntaxTree) -> i32 {
         let mut return_code = 0;
 
         for statement in ast.statements() {
@@ -40,7 +41,7 @@ impl Evaluator {
         return_code
     }
 
-    fn evaluate_statement(&mut self, statement: &Statement) -> Option<i64> {
+    fn evaluate_statement(&mut self, statement: &Statement) -> Option<i32> {
         match &statement {
             Statement::Let(let_statement) => match &*let_statement.expression {
                 Expression::StringLiteral(string_literal) => {
@@ -95,7 +96,7 @@ mod tests {
 
     struct EvaluatorTestCase {
         input: &'static str,
-        return_value: i64,
+        return_value: i32,
     }
 
     #[test]

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -84,7 +84,7 @@ impl Evaluator {
                             Value::Integer(integer) => return Some(*integer),
                             _ => panic!(
                                 "Unhandled identifier kind in top-level return statement {:?}",
-                                &*_return_statement.expression
+                                &*return_statement.expression
                             ),
                         }
                     } else {

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -78,6 +78,19 @@ impl Evaluator {
                     );
                 }
                 Expression::Integer(integer) => return Some(integer.value),
+                Expression::Identifier(identifier) => {
+                    if let Some(value) = self.globals.values.get(&identifier.name) {
+                        match &value {
+                            Value::Integer(integer) => return Some(*integer),
+                            _ => panic!(
+                                "Unhandled identifier kind in top-level return statement {:?}",
+                                &*_return_statement.expression
+                            ),
+                        }
+                    } else {
+                        panic!("Return of unknown value '{:?}'", identifier.name);
+                    }
+                }
                 _ => {
                     panic!(
                         "Unhandled expression kind in top-level return statement {:?}",
@@ -117,6 +130,10 @@ mod tests {
             EvaluatorTestCase {
                 input: "let a = 42;",
                 return_value: 0,
+            },
+            EvaluatorTestCase {
+                input: "let a = 42; return a;",
+                return_value: 42,
             },
             EvaluatorTestCase {
                 input: r#"let a = 42; let b = "Hello"; let c = 3.14159; return 7;"#,

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,18 +9,37 @@ use std::{
     io::{self, Read, Write},
 };
 
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// A lexer, parser, interpreter, JIT and AOT compiler and
+/// runtime written in Rust for a new (simple) language
+#[derive(StructOpt, Debug)]
+#[structopt(name = "mylang")]
+pub struct Opt {
+    /// Files to process
+    #[structopt(name = "FILE", parse(from_os_str))]
+    files: Vec<PathBuf>,
+}
+
 /// process first filepath in the input Vec, or stdin if empty
-pub fn process_files(filepaths: Vec<String>) -> Result<i64> {
+///
+/// # Errors
+///
+/// Will return Err if files couldn't be opened, or found
+/// or if they could not be lexed, parsed or evaluated
+pub fn process_files(opt: &Opt) -> Result<i64> {
     let stdout = io::stdout();
     let mut outio = stdout.lock();
 
-    if filepaths.is_empty() {
+    if opt.files.is_empty() {
         process_stream(io::stdin(), &mut outio).with_context(|| "while reading stdin")
     } else {
-        let filepath = &filepaths[0];
+        let filepath = &opt.files[0];
         let file = File::open(&filepath)
-            .with_context(|| format!("Failed to open file at {}", filepath))?;
-        process_stream(file, &mut outio).with_context(|| format!("while reading {}", filepath))
+            .with_context(|| format!("Failed to open file at {}", filepath.display()))?;
+        process_stream(file, &mut outio)
+            .with_context(|| format!("while reading {}", filepath.display()))
     }
 }
 
@@ -72,7 +91,7 @@ fn process_text<W: Write>(text: &str, mut out: W) -> Result<i64> {
     for err in evaluator.errors() {
         writeln!(out, "{}", err)?;
     }
-    result
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -90,7 +109,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "Failed to open file at /dev/null/madeupfile")]
     fn missing_file_causes_a_panic() {
-        process_files(vec!["/dev/null/madeupfile".to_string()]).unwrap();
+        let opts = Opt {
+            files: vec![PathBuf::from(r"/dev/null/madeupfile")],
+        };
+        process_files(&opts).unwrap();
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -22,13 +22,13 @@ pub struct Opt {
     files: Vec<PathBuf>,
 }
 
-/// process first filepath in the input Vec, or stdin if empty
+/// process first filepath in Files, or stdin if empty
 ///
 /// # Errors
 ///
 /// Will return Err if files couldn't be opened, or found
 /// or if they could not be lexed, parsed or evaluated
-pub fn process_files(opt: &Opt) -> Result<i64> {
+pub fn process_files(opt: &Opt) -> Result<i32> {
     let stdout = io::stdout();
     let mut outio = stdout.lock();
 
@@ -45,7 +45,7 @@ pub fn process_files(opt: &Opt) -> Result<i64> {
 
 /// process an input stream from inio, reading its text and writing the
 /// processed results to outio
-fn process_stream<R, W>(mut inio: R, outio: W) -> Result<i64>
+fn process_stream<R, W>(mut inio: R, outio: W) -> Result<i32>
 where
     R: Read,
     W: Write,
@@ -59,7 +59,7 @@ where
 /// process an input text, writing a printable form of all tokens except
 /// whitespace, one token per line onto out. Line numbers and columns are
 /// written. Any AST errors are written
-fn process_text<W: Write>(text: &str, mut out: W) -> Result<i64> {
+fn process_text<W: Write>(text: &str, mut out: W) -> Result<i32> {
     let lexer = Lexer::new(text);
     let tokens = lexer.tokens();
     for token in &tokens {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -331,6 +331,8 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
+
     fn lexer() {
         let test_cases = vec![
             TestCase {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+pub mod driver;
 mod evaluator;
-pub mod io;
 mod lexer;
 mod parser;
 mod token;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
-use mylang::io::process_files;
-use std::{env, process};
+use mylang::io::{process_files, Opt};
+use std::process;
+use structopt::StructOpt;
 
 fn main() -> Result<()> {
-    process::exit(process_files(env::args().skip(1).collect())? as i32)
+    let opt = Opt::from_args();
+    #[allow(clippy::cast_possible_truncation)]
+    process::exit(process_files(&opt)? as i32)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,5 @@ use structopt::StructOpt;
 
 fn main() -> Result<()> {
     let opt = Opt::from_args();
-    #[allow(clippy::cast_possible_truncation)]
-    process::exit(process_files(&opt)? as i32)
+    process::exit(process_files(&opt)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
-use mylang::io::{process_files, Opt};
+use mylang::driver::{go, Opt};
 use std::process;
 use structopt::StructOpt;
 
 fn main() -> Result<()> {
-    let opt = Opt::from_args();
-    process::exit(process_files(&opt)?)
+    process::exit(go(&Opt::from_args())?)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -73,7 +73,7 @@ impl AbstractSyntaxTree {
     pub const fn errors(&self) -> &Vec<String> {
         &self.errors
     }
-    pub fn statements(&self) -> &Vec<Statement> {
+    pub const fn statements(&self) -> &Vec<Statement> {
         &self.statements
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ pub struct StringLiteralExpression {
 }
 #[derive(Debug)]
 pub struct IntegerExpression {
-    pub value: i64,
+    pub value: i32,
 }
 #[derive(Debug)]
 pub struct FloatingPointExpression {
@@ -306,7 +306,7 @@ impl<'a> Parser<'a> {
 
         match self.token.kind() {
             Kind::Integer => {
-                if let Ok(value) = self.token.text().parse::<i64>() {
+                if let Ok(value) = self.token.text().parse::<i32>() {
                     self.read_token(); // consume `value`
                     Some(IntegerExpression { value })
                 } else {


### PR DESCRIPTION
* simplest possible use of `structopt` crate (to be extended later) to handle phases
* silence a clippy warning
* correct evaluator evaluation of statements to return the value of the last statement evaluated
* remove Result where it was unused
* rename `io` to `driver`

Note that `structopt` now lets us do command-line things like:
`cargo run -- --help`
`cargo run -- --version`

and will let us do #37 next

Fixes #40 