### PR TITLE
Parse and evaluate identifier expression.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -65,7 +65,7 @@ pub struct ReturnStatement {
 
 #[derive(Debug)]
 pub enum Statement {
-    // Expression(Expression),
+    Expression(Expression),
     Let(LetStatement),
     Return(ReturnStatement),
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn valid_utf8_input_doesnt_panic() {
-        let valid_utf8: &[u8] = b"meow";
+        let valid_utf8: &[u8] = b"let meow; meow";
         process_stream(valid_utf8, io::sink()).unwrap();
     }
 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -91,6 +91,10 @@ return first(101, 2);"#,
                 input: r#"let a = 42; let b = "Hello"; let c = 3.14159; return 7;"#,
                 return_value: 7,
             },
+            EvaluatorTestCase {
+                input: r#"let a = 42; a;"#,
+                return_value: 0, // not 42
+            },
         ];
 
         for test_case in test_cases {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -86,6 +86,11 @@ impl<'a> Frame<'a> {
                 let value = self.evaluate_expression(&return_statement.expression);
                 Some(value)
             }
+            Statement::Expression(expression) => {
+                let _value = self.evaluate_expression(expression);
+                // TODO: Print _value to the console if we're in a REPL.
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
Do not (yet) extend evaluator to be a REPL so that top-level statement
expressions are printed to the console.

Used as part of #64 