### PR TITLE
Factor complex logic out of main token matching.

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -75,13 +75,7 @@ impl<'a> Lexer<'a> {
             '-' => self.char_token(Kind::Minus),
             '*' => self.char_token(Kind::Star),
             '/' => self.char_token(Kind::Divide),
-            '.' => {
-                if self.peek_char().is_ascii_digit() {
-                    self.read_decimal_part(self.position)
-                } else {
-                    self.char_token(Kind::Period)
-                }
-            }
+            '.' => self.read_period_or_decimal_token(),
             '=' => match self.peek_char() {
                 '=' => {
                     let start = self.position;
@@ -125,25 +119,7 @@ impl<'a> Lexer<'a> {
             ']' => self.char_token(Kind::RightSqBracket),
             '#' => self.read_comment(),
             '"' => self.read_string(),
-            _ => {
-                // read whitespace
-                if c.is_whitespace() {
-                    self.read_whitespace()
-                }
-                // read keyword or identifier
-                else if c.is_ascii_alphabetic() {
-                    self.read_keyword()
-                        .map_or_else(|| self.read_identifier(), |t| t)
-                }
-                // read number
-                else if c.is_ascii_digit() {
-                    self.read_number().map_or_else(|| self.read_junk(), |t| t)
-                }
-                // read junk
-                else {
-                    self.read_junk()
-                }
-            }
+            _ => self.read_non_special_token(c),
         };
 
         self.read_char();
@@ -156,6 +132,34 @@ impl<'a> Lexer<'a> {
 
     fn text_token(&self, start: usize, kind: Kind) -> Token<'a> {
         Token::new(self.text_range(start), start, kind)
+    }
+
+    fn read_non_special_token(&mut self, c: char) -> Token<'a> {
+        // read whitespace
+        if c.is_whitespace() {
+            self.read_whitespace()
+        }
+        // read keyword or identifier
+        else if c.is_ascii_alphabetic() {
+            self.read_keyword()
+                .map_or_else(|| self.read_identifier(), |t| t)
+        }
+        // read number
+        else if c.is_ascii_digit() {
+            self.read_number().map_or_else(|| self.read_junk(), |t| t)
+        }
+        // read junk
+        else {
+            self.read_junk()
+        }
+    }
+
+    fn read_period_or_decimal_token(&mut self) -> Token<'a> {
+        if self.peek_char().is_ascii_digit() {
+            self.read_decimal_part(self.position)
+        } else {
+            self.char_token(Kind::Period)
+        }
     }
 
     fn read_junk(&mut self) -> Token<'a> {


### PR DESCRIPTION
This commit factors out two more complex if/else blocks from the matcher
for tokens. This has two effects:

1. The main matching logic becomes easier to read without nested if/else
   blocks for more complex matching.

2. `cargo tarpaulin` no longer reports lines are not covered because
   there is no executable code on that line. By moving the complex logic
   into a function, and putting a call to the function on the same line
   as the pattern, `tarpaulin` now correctly sees that it is covered.

Note that the equivalent refactoring was not done for the nested match
of `!=`, `>=` and `<=` as these are simple matches with no `if`
conditions, and there is benefit to having the full matching logic for
all such operators/symbols expressed directly in the matcher block.

There is a minor hit to locality of knowledge; that is, finding the
logic for tokenizing certain things requires more searching, but the
function names should be sufficiently descriptive to make this
near-trivial. For example, instead of the inlined logic to distinguish a
period token from a `.123` style decimal literal, the function is named
`read_period_or_decimal_token`. This should still provide sufficient
context for readers of the main match block to find the relevant code
further down.