### PR TITLE
Avoid unnecessary braced block in `read_string`.

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -236,9 +236,7 @@ impl<'a> Lexer<'a> {
                     self.read_char(); // Consume closing '"'.
                     break;
                 }
-                _ => {
-                    self.read_char();
-                }
+                _ => self.read_char(),
             }
         }
         self.text_token(start, kind)


### PR DESCRIPTION
This allows the code coverage measure to correctly identify that the
default match is hit.