### PR TITLE
* unify UnaryPlus and UnaryMinus into UnaryOp

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,16 +5,22 @@ pub struct Call {
 }
 
 #[derive(Debug)]
-pub enum UnaryPlus {
+pub enum PlusOrMinus {
+    Plus,
+    Minus,
+}
+
+#[derive(Debug)]
+pub enum UnaryTarget {
     Integer(i32),
-    FloatingPoint(f64),
+    Float(f64),
     Identifier(String),
 }
+
 #[derive(Debug)]
-pub enum UnaryMinus {
-    Integer(i32),
-    FloatingPoint(f64),
-    Identifier(String),
+pub struct UnaryOp {
+    pub sign: PlusOrMinus,
+    pub target: UnaryTarget,
 }
 
 #[derive(Debug)]
@@ -26,14 +32,13 @@ pub struct Function {
 #[derive(Debug)]
 pub enum Expression {
     Boolean(bool),
-    FloatingPoint(f64),
+    Float(f64),
     Function(Function),
     Call(Call),
     Identifier(String),
     Integer(i32),
     StringLiteral(String),
-    UnaryMinus(UnaryMinus),
-    UnaryPlus(UnaryPlus),
+    UnaryOp(UnaryOp),
 }
 #[derive(Debug)]
 pub struct Let {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -19,7 +19,7 @@ pub enum UnaryTarget {
 
 #[derive(Debug)]
 pub struct UnaryOp {
-    pub sign: PlusOrMinus,
+    pub operation: PlusOrMinus,
     pub target: UnaryTarget,
 }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -31,7 +31,7 @@ impl<'a> Frame<'a> {
     fn evaluate_expression(&mut self, expression: &'a Expression) -> Rc<Value<'a>> {
         match expression {
             Expression::Boolean(b) => Rc::new(Value::Boolean(*b)),
-            Expression::FloatingPoint(f) => Rc::new(Value::Float(*f)),
+            Expression::Float(f) => Rc::new(Value::Float(*f)),
             Expression::Function(function) => Rc::new(Value::Function(function)),
             Expression::Integer(i) => Rc::new(Value::Integer(*i)),
             Expression::StringLiteral(s) => Rc::new(Value::String(s.clone())),
@@ -74,7 +74,7 @@ impl<'a> Frame<'a> {
                     panic!("Unknown identifier {:?}", expression)
                 }
             }
-            Expression::UnaryPlus(_) | Expression::UnaryMinus(_) => todo!(),
+            Expression::UnaryOp(_) => todo!(),
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -307,7 +307,7 @@ impl<'a> Lexer<'a> {
             // as they form the beginning of the next token.
             self.read_number_cleanup_junk(start)
         } else {
-            self.text_token(start, Kind::FloatingPoint)
+            self.text_token(start, Kind::Float)
         }
     }
 
@@ -621,7 +621,7 @@ mod tests {
     lexer_test_case! {
         name: float,
         input: "3.14",
-        expected_tokens: vec![("3.14", Kind::FloatingPoint)],
+        expected_tokens: vec![("3.14", Kind::Float)],
     }
 
     lexer_test_case! {
@@ -639,37 +639,37 @@ mod tests {
     lexer_test_case! {
         name: float_with_trailing_dot,
         input: "3.",
-        expected_tokens: vec![("3.", Kind::FloatingPoint)],
+        expected_tokens: vec![("3.", Kind::Float)],
     }
 
     lexer_test_case! {
         name: float_with_leading_dot,
         input: ".14",
-        expected_tokens: vec![(".14", Kind::FloatingPoint)],
+        expected_tokens: vec![(".14", Kind::Float)],
     }
 
     lexer_test_case! {
         name: float_with_exponent,
         input: "3e8",
-        expected_tokens: vec![("3e8", Kind::FloatingPoint)],
+        expected_tokens: vec![("3e8", Kind::Float)],
     }
 
     lexer_test_case! {
         name: float_with_exponent_and_dot,
         input: "0.314e1",
-        expected_tokens: vec![("0.314e1", Kind::FloatingPoint)],
+        expected_tokens: vec![("0.314e1", Kind::Float)],
     }
 
     lexer_test_case! {
         name: float_with_negative_exponent_and_dot,
         input: "9.1e-31",
-        expected_tokens: vec![("9.1e-31", Kind::FloatingPoint)],
+        expected_tokens: vec![("9.1e-31", Kind::Float)],
     }
 
     lexer_test_case! {
         name: float_with_positive_exponent_and_dot,
         input: "6.02e+23",
-        expected_tokens: vec![("6.02e+23", Kind::FloatingPoint)],
+        expected_tokens: vec![("6.02e+23", Kind::Float)],
     }
 
     lexer_test_case! {
@@ -702,7 +702,7 @@ mod tests {
         expected_tokens: vec![
             ("123f", Kind::Unknown),
             ("+", Kind::Plus),
-            ("4.2e-3", Kind::FloatingPoint),
+            ("4.2e-3", Kind::Float),
         ],
     }
 
@@ -716,9 +716,9 @@ mod tests {
         name: bad_float_with_dot_and_exponent_with_float,
         input: "1.23e-4+3.2e-5",
         expected_tokens: vec![
-            ("1.23e-4", Kind::FloatingPoint),
+            ("1.23e-4", Kind::Float),
             ("+", Kind::Plus),
-            ("3.2e-5", Kind::FloatingPoint),
+            ("3.2e-5", Kind::Float),
         ],
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -156,7 +156,12 @@ impl<'a> Parser<'a> {
             Kind::Float => self.parse_float().map(Expression::Float),
             Kind::String => Some(Expression::StringLiteral(self.parse_string())),
             Kind::Function => self.parse_function().map(Expression::Function),
-            Kind::Minus | Kind::Plus => self.parse_unary_op().map(Expression::UnaryOp),
+            Kind::Plus => self
+                .parse_unary_op(PlusOrMinus::Plus)
+                .map(Expression::UnaryOp),
+            Kind::Minus => self
+                .parse_unary_op(PlusOrMinus::Minus)
+                .map(Expression::UnaryOp),
             Kind::True | Kind::False => Some(Expression::Boolean(self.parse_bool())),
             _ => {
                 self.errors.push(format!(
@@ -213,13 +218,9 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_unary_op(&mut self) -> Option<UnaryOp> {
+    fn parse_unary_op(&mut self, operation: PlusOrMinus) -> Option<UnaryOp> {
         assert!(self.token.kind() == Kind::Plus || self.token.kind() == Kind::Minus);
-        let sign = if self.token.kind() == Kind::Plus {
-            PlusOrMinus::Plus
-        } else {
-            PlusOrMinus::Minus
-        };
+
         self.read_token(); // consume `+` or `-`
         let operand = match self.token.kind() {
             Kind::Integer => self.parse_integer().map(UnaryTarget::Integer),
@@ -233,7 +234,7 @@ impl<'a> Parser<'a> {
                 None
             }
         };
-        operand.map(|target| UnaryOp { sign, target })
+        operand.map(|target| UnaryOp { operation, target })
     }
 
     fn parse_bool(&mut self) -> bool {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,8 @@
 use crate::{
-    ast::{AbstractSyntaxTree, Call, Expression, Function, Let, Statement, UnaryMinus, UnaryPlus},
+    ast::{
+        AbstractSyntaxTree, Call, Expression, Function, Let, PlusOrMinus, Statement, UnaryOp,
+        UnaryTarget,
+    },
     token::{Kind, Token},
 };
 pub struct Parser<'a> {
@@ -150,11 +153,10 @@ impl<'a> Parser<'a> {
                 None => Some(Expression::Identifier(self.parse_string())),
             },
             Kind::Integer => self.parse_integer().map(Expression::Integer),
-            Kind::FloatingPoint => self.parse_float().map(Expression::FloatingPoint),
+            Kind::Float => self.parse_float().map(Expression::Float),
             Kind::String => Some(Expression::StringLiteral(self.parse_string())),
             Kind::Function => self.parse_function().map(Expression::Function),
-            Kind::Plus => self.parse_unary_plus().map(Expression::UnaryPlus),
-            Kind::Minus => self.parse_unary_minus().map(Expression::UnaryMinus),
+            Kind::Minus | Kind::Plus => self.parse_unary_op().map(Expression::UnaryOp),
             Kind::True | Kind::False => Some(Expression::Boolean(self.parse_bool())),
             _ => {
                 self.errors.push(format!(
@@ -211,38 +213,27 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_unary_plus(&mut self) -> Option<UnaryPlus> {
-        assert!(self.token.kind() == Kind::Plus);
-        self.read_token(); // consume `+`
-        match self.token.kind() {
-            Kind::Integer => self.parse_integer().map(UnaryPlus::Integer),
-            Kind::FloatingPoint => self.parse_float().map(UnaryPlus::FloatingPoint),
-            Kind::Identifier => Some(UnaryPlus::Identifier(self.parse_string())),
+    fn parse_unary_op(&mut self) -> Option<UnaryOp> {
+        assert!(self.token.kind() == Kind::Plus || self.token.kind() == Kind::Minus);
+        let sign = if self.token.kind() == Kind::Plus {
+            PlusOrMinus::Plus
+        } else {
+            PlusOrMinus::Minus
+        };
+        self.read_token(); // consume `+` or `-`
+        let operand = match self.token.kind() {
+            Kind::Integer => self.parse_integer().map(UnaryTarget::Integer),
+            Kind::Float => self.parse_float().map(UnaryTarget::Float),
+            Kind::Identifier => Some(UnaryTarget::Identifier(self.parse_string())),
             _ => {
                 self.errors.push(format!(
-                    "Parse error when parsing unary plus expression {:?}",
+                    "Parse error when parsing unary operation's target {:?}",
                     self.token
                 ));
                 None
             }
-        }
-    }
-
-    fn parse_unary_minus(&mut self) -> Option<UnaryMinus> {
-        assert!(self.token.kind() == Kind::Minus);
-        self.read_token(); // consume `-`
-        match self.token.kind() {
-            Kind::Integer => self.parse_integer().map(UnaryMinus::Integer),
-            Kind::FloatingPoint => self.parse_float().map(UnaryMinus::FloatingPoint),
-            Kind::Identifier => Some(UnaryMinus::Identifier(self.parse_string())),
-            _ => {
-                self.errors.push(format!(
-                    "Parse error when parsing unary minus expression {:?}",
-                    self.token
-                ));
-                None
-            }
-        }
+        };
+        operand.map(|target| UnaryOp { sign, target })
     }
 
     fn parse_bool(&mut self) -> bool {
@@ -269,9 +260,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_float(&mut self) -> Option<f64> {
-        assert!(self.token.kind() == Kind::FloatingPoint);
+        assert!(self.token.kind() == Kind::Float);
         match self.token.kind() {
-            Kind::FloatingPoint => {
+            Kind::Float => {
                 if let Ok(value) = self.token.text().parse::<f64>() {
                     self.read_token(); // consume `value`
                     Some(value)

--- a/src/token.rs
+++ b/src/token.rs
@@ -10,7 +10,7 @@ pub enum Kind {
     EndOfFile,
     EqualSign,
     False,
-    FloatingPoint,
+    Float,
     Function,
     Greater,
     GreaterOrEqual,


### PR DESCRIPTION
Fixes #86 

* unify UnaryPlus and UnaryMinus into UnaryOp
* rename FloatingPoint to Float
* Note that unary operations are still unimplemented in the Evaluator