### PR TITLE
lifetimes and Rcs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 #[derive(Debug)]
 pub struct Call {
     pub(crate) name: String,
@@ -26,7 +28,7 @@ pub struct Function {
 pub enum Expression {
     Boolean(bool),
     Float(f64),
-    Function(Function),
+    Function(Rc<Function>),
     Call(Call),
     Identifier(String),
     Integer(i32),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,14 +1,14 @@
 use crate::ast::AbstractSyntaxTree;
 use crate::frame::{Frame, Value};
 
-pub struct Evaluator<'a> {
-    global: Frame<'a>,
+pub struct Evaluator {
+    global: Frame,
     errors: Vec<String>,
 }
 
-impl<'a> Evaluator<'a> {
+impl<'a> Evaluator {
     pub(crate) fn new() -> Self {
-        Evaluator {
+        Self {
             global: Frame::new(),
             errors: vec![],
         }
@@ -18,7 +18,7 @@ impl<'a> Evaluator<'a> {
         &self.errors
     }
 
-    pub(crate) fn evaluate(&mut self, ast: &'a AbstractSyntaxTree) -> i32 {
+    pub(crate) fn evaluate(&mut self, ast: &AbstractSyntaxTree) -> i32 {
         // Evaluate statements at global scope until one of them returns.
         if let Some(rc) = self.global.evaluate_body(ast.statements()) {
             match *rc {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,25 +1,27 @@
 use crate::ast::{Expression, Function, OpName, Statement, UnaryOp};
 use std::{collections::HashMap, rc::Rc};
 
-pub enum Value<'a> {
+#[derive(Debug)]
+pub enum Value {
     Boolean(bool),
     Float(f64),
-    Function(&'a Function),
+    Function(Rc<Function>),
     Integer(i32),
     String(String),
 }
-pub struct Frame<'a> {
-    values: HashMap<String, Rc<Value<'a>>>,
+
+pub struct Frame {
+    values: HashMap<String, Rc<Value>>,
 }
 
-impl<'a> Frame<'a> {
+impl Frame {
     pub(crate) fn new() -> Self {
         Self {
             values: HashMap::new(),
         }
     }
 
-    pub(crate) fn evaluate_body(&mut self, body: &'a [Statement]) -> Option<Rc<Value<'a>>> {
+    pub(crate) fn evaluate_body(&mut self, body: &[Statement]) -> Option<Rc<Value>> {
         for statement in body {
             if let Some(v) = self.evaluate_statement(statement) {
                 return Some(v);
@@ -28,11 +30,11 @@ impl<'a> Frame<'a> {
         None
     }
 
-    fn evaluate_expression(&mut self, expression: &'a Expression) -> Rc<Value<'a>> {
+    fn evaluate_expression(&self, expression: &Expression) -> Rc<Value> {
         match expression {
             Expression::Boolean(b) => Rc::new(Value::Boolean(*b)),
             Expression::Float(f) => Rc::new(Value::Float(*f)),
-            Expression::Function(function) => Rc::new(Value::Function(function)),
+            Expression::Function(function) => Rc::new(Value::Function(function.clone())),
             Expression::Integer(i) => Rc::new(Value::Integer(*i)),
             Expression::StringLiteral(s) => Rc::new(Value::String(s.clone())),
             Expression::Identifier(identifier) => {
@@ -44,7 +46,7 @@ impl<'a> Frame<'a> {
             }
             Expression::Call(call) => {
                 if let Some(value) = self.values.get(&call.name) {
-                    match **value {
+                    match &**value {
                         Value::Boolean(_) => panic!("Cannot call a boolean"),
                         Value::Float(_) => panic!("Cannot call a float"),
                         Value::Integer(_) => panic!("Cannot call an integer"),
@@ -53,7 +55,7 @@ impl<'a> Frame<'a> {
                             if function.arguments.len() != call.arguments.len() {
                                 panic!("Mismatch in argument count for function {}. Expected {} arguments but got {}", call.name, function.arguments.len(), call.arguments.len());
                             }
-                            let mut function_frame = Frame::new();
+                            let mut function_frame = Self::new();
                             for (arg_name, arg_expression) in
                                 function.arguments.iter().zip(call.arguments.iter())
                             {
@@ -78,7 +80,7 @@ impl<'a> Frame<'a> {
         }
     }
 
-    fn evaluate_statement(&mut self, statement: &'a Statement) -> Option<Rc<Value<'a>>> {
+    fn evaluate_statement(&mut self, statement: &Statement) -> Option<Rc<Value>> {
         match &statement {
             Statement::Let(let_statement) => {
                 let value = self.evaluate_expression(&let_statement.expression);
@@ -94,7 +96,7 @@ impl<'a> Frame<'a> {
         }
     }
 
-    fn evaluate_unary_op(&mut self, op: &'a UnaryOp) -> Rc<Value<'a>> {
+    fn evaluate_unary_op(&self, op: &UnaryOp) -> Rc<Value> {
         let target = self.evaluate_expression(&op.target);
         match *target {
             Value::Boolean(_) => panic!("Cannot apply a unary operation to a Boolean"),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::{
     ast::{AbstractSyntaxTree, Call, Expression, Function, Let, OpName, Statement, UnaryOp},
     token::{Kind, Token},
@@ -274,7 +276,7 @@ impl<'a> Parser<'a> {
     //     statement*
     //   };"
     // Indenting is not checked.
-    fn parse_function(&mut self) -> Option<Function> {
+    fn parse_function(&mut self) -> Option<Rc<Function>> {
         assert!(self.token.kind() == Kind::Function);
         let start = self.position;
         self.read_token(); // consume "fn"
@@ -339,7 +341,7 @@ impl<'a> Parser<'a> {
         assert_eq!(self.token.kind(), Kind::RightBrace);
         self.read_token(); // consume "}"
 
-        Some(Function { arguments, body })
+        Some(Rc::new(Function { arguments, body }))
     }
 
     fn parse_expression_statement(&mut self) -> Option<Expression> {


### PR DESCRIPTION
* Remove lifetime specifiers in `ast`/`frame`/`evaluator`/`parser`
* Multiple `Expression`s and `Value`s can share an `Rc<Function>`
* Fix some explicit names to be `Self`

I am not actually sure if we would prefer the lifetimes or the `Rc`. Will lifetimes be a problem later (because they are viral)? Will the AST of everything stick around, even in a REPL, so that lifetimes are ok to use rather than `Rc`s?

Please have a think on this and comment. I won't mind if we throw this code out if that's what we want.