### PR TITLE
Rename Frame to Environment

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -47,11 +47,11 @@ pub enum EvaluationError {
     },
 }
 
-pub struct Frame {
+pub struct Environment {
     values: HashMap<String, Rc<Value>>,
 }
 
-impl Frame {
+impl Environment {
     pub(crate) fn new() -> Self {
         Self {
             values: HashMap::new(),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,8 +1,8 @@
 use crate::ast::AbstractSyntaxTree;
-use crate::frame::{EvaluationError, Frame, Value};
+use crate::environment::{Environment, EvaluationError, Value};
 use thiserror::Error;
 pub struct Evaluator {
-    global: Frame,
+    global: Environment,
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -19,7 +19,7 @@ pub enum Error {
 impl<'a> Evaluator {
     pub(crate) fn new() -> Self {
         Self {
-            global: Frame::new(),
+            global: Environment::new(),
         }
     }
 
@@ -37,8 +37,8 @@ impl<'a> Evaluator {
 #[cfg(test)]
 mod tests {
     use crate::{
+        environment::EvaluationError,
         evaluator::{Error, Evaluator},
-        frame::EvaluationError,
         lexer::Lexer,
         parser::Parser,
     };

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -338,13 +338,6 @@ impl<'a> Lexer<'a> {
 mod tests {
     use super::*;
 
-    #[derive(Debug)]
-    struct TestCase {
-        input: &'static str,
-        skip_whitespace: bool,
-        expected_tokens: Vec<(&'static str, Kind)>,
-    }
-
     macro_rules! lexer_test_case {
         ( name: $test_name:ident, input: $input:expr, expected_tokens:$expected_tokens:expr,) => {
             #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod ast;
 pub mod driver;
+mod environment;
 mod evaluator;
-mod frame;
 mod lexer;
 #[cfg(test)]
 mod matcher;


### PR DESCRIPTION
Save 'Frame' for stack frames if we create a stack-based evaluator.