### PR TITLE
Remove quotes from string literals.

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -151,7 +151,7 @@ impl fmt::Display for Expression {
             Expression::Float(f) => write!(formatter, "{}", f),
             Expression::Identifier(i) => write!(formatter, "{}", i),
             Expression::Integer(i) => write!(formatter, "{}", i),
-            Expression::StringLiteral(s) => write!(formatter, "{}", s),
+            Expression::StringLiteral(s) => write!(formatter, r#""{}""#, s),
             Expression::Call(c) => write!(formatter, "{}", c),
             Expression::UnaryOp(op) => write!(formatter, "{}", op),
             Expression::BinaryOp(op) => write!(formatter, "{}", op),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -245,7 +245,7 @@ mod tests {
     evaluator_error_test_case! {
         name: return_string_err,
         input: r#"return "meow";"#,
-        err_value: Error::NonPermitted(r#"String("meow")"#.to_string()),
+        err_value: Error::NonPermitted("String(meow)".to_string()),
     }
 
     evaluator_error_test_case! {
@@ -254,7 +254,7 @@ mod tests {
         err_value: Error::Evaluation{
             source: EvaluationError::IllegalUnaryOperation{
                 opname: "-".to_string(),
-                value:"String(\"Hello\")".to_string()
+                value:"String(Hello)".to_string()
             }
         },
     }
@@ -290,7 +290,7 @@ mod tests {
         name: call_string_err,
         input: r#"let x = "hello"; return x();"#,
         err_value: Error::Evaluation{
-            source: EvaluationError::NonCallableType("String(\"hello\")".to_string())
+            source: EvaluationError::NonCallableType("String(hello)".to_string())
         },
     }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -571,7 +571,7 @@ mod tests {
     matcher_test_case! {
         name: string_matcher,
         input: r#"return "Hello";"#,
-        matcher: match_descend!(match_string!(r#""Hello""#.to_string())),
+        matcher: match_descend!(match_string!("Hello".to_string())),
     }
 
     matcher_test_case! {


### PR DESCRIPTION
Split function for parsing identifiers and strings into two functions